### PR TITLE
Add OPENAI key check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+if (!process.env.OPENAI_API_KEY) {
+  console.error('Error: OPENAI_API_KEY environment variable is not set.');
+  process.exit(1);
+}
+
+// Additional application code can be added here.
+


### PR DESCRIPTION
## Summary
- add a simple `index.js` entry
- exit with an error message when `OPENAI_API_KEY` isn't set

## Testing
- `node index.js` *(fails without key)*
- `OPENAI_API_KEY=sk-test node index.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685914f170b4832991a28a06ece6f8b4